### PR TITLE
feat: Add Taekwondo members area and redirect

### DIFF
--- a/app/Http/Controllers/ProgramController.php
+++ b/app/Http/Controllers/ProgramController.php
@@ -8,12 +8,22 @@ use Illuminate\Support\Facades\Cache;
 use Inertia\Inertia;
 use Inertia\Response as InertiaResponse;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Auth; // Added import
+use Illuminate\Support\Facades\Redirect; // Added import
 use Illuminate\Support\Str;
 
 class ProgramController extends Controller
 {
     public function show(string $slug): InertiaResponse
     {
+        // Check for Taekwondo slug and user tkd attribute
+        if ($slug === 'taekwondo') {
+            $user = Auth::user();
+            if ($user && $user->tkd === true) {
+                return Redirect::route('programs.taekwondo.members');
+            }
+        }
+
         // Get the current locale
         $locale = App::getLocale();
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,6 +23,7 @@ class User extends Authenticatable
         'last_name',
         'email',
         'password',
+        'tkd',
     ];
     protected function name(): Attribute
     {

--- a/database/migrations/2025_05_22_155044_add_tkd_to_users_table.php
+++ b/database/migrations/2025_05_22_155044_add_tkd_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('tkd')->default(false)->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('tkd');
+        });
+    }
+};

--- a/resources/js/Pages/Programs/Taekwondo/Members.vue
+++ b/resources/js/Pages/Programs/Taekwondo/Members.vue
@@ -1,0 +1,23 @@
+<template>
+  <DefaultLayout>
+    <div>
+      <h1>Welcome Taekwondo Members</h1>
+      <p>This is the exclusive members area for Taekwondo practitioners.</p>
+    </div>
+  </DefaultLayout>
+</template>
+
+<script setup lang="ts">
+import DefaultLayout from '@/Layouts/DefaultLayout.vue'; // Assuming DefaultLayout exists
+</script>
+
+<style scoped>
+h1 {
+  font-size: 2em;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+p {
+  text-align: center;
+}
+</style>

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,11 @@ Route::get('/news', [NewsController::class, 'index']);
 Route::get('/contact', [ContactController::class, 'show'])->name('contact.show');
 Route::post('/contact', [ContactController::class, 'store'])
     ->name('contact.store');
+
+Route::get('/programs/taekwondo/members', function () {
+    return Inertia::render('Programs/Taekwondo/Members');
+})->middleware('auth')->name('programs.taekwondo.members');
+
     Route::get('/programs/{slug}', [ProgramController::class, 'show'])
 ->where('slug','.*')
     ->name('program.show');

--- a/tests/Feature/TaekwondoProgramTest.php
+++ b/tests/Feature/TaekwondoProgramTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Program; // Assuming Program model exists
+use Inertia\Testing\AssertableInertia as Assert;
+
+class TaekwondoProgramTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test that a taekwondo member is redirected to the members area.
+     */
+    public function test_taekwondo_member_is_redirected(): void
+    {
+        // Create a user with tkd = true
+        $user = User::factory()->create(['tkd' => true]);
+
+        // Authenticate as this user
+        $this->actingAs($user);
+
+        // Make a GET request to /programs/taekwondo
+        $response = $this->get('/programs/taekwondo');
+
+        // Assert that the response is a redirect to /programs/taekwondo/members
+        $response->assertStatus(302);
+        $response->assertRedirect('/programs/taekwondo/members');
+    }
+
+    /**
+     * Test that a non-taekwondo member sees the taekwondo page.
+     */
+    public function test_non_taekwondo_member_sees_taekwondo_page(): void
+    {
+        // Create a user with tkd = false
+        $user = User::factory()->create(['tkd' => false]);
+
+        // Authenticate as this user
+        $this->actingAs($user);
+        
+        // Create a Taekwondo program manually if factory is not available
+        Program::create([
+            'title' => 'Taekwondo Program',
+            'slug' => 'taekwondo',
+            // Add other required fields for the Program model if any
+            // For example, assuming 'description' is a required field:
+            'description' => 'A default description', 
+            'published' => true, // Assuming published is needed for visibility
+        ]);
+
+
+        // Make a GET request to /programs/taekwondo
+        $response = $this->get('/programs/taekwondo');
+
+        // Assert that the response is successful (status 200)
+        // And renders the correct Inertia component
+        $response->assertStatus(200);
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('Programs/Taekwondo')
+            // Optionally check for props if needed
+            // ->has('item.title', 'Taekwondo Program')
+        );
+    }
+
+    /**
+     * Test that an unauthenticated user is redirected from the members page.
+     */
+    public function test_unauthenticated_user_redirected_from_members_page(): void
+    {
+        // Make a GET request to /programs/taekwondo/members without authenticating
+        $response = $this->get('/programs/taekwondo/members');
+
+        // Assert that the response is a redirect to the login page
+        $response->assertStatus(302);
+        $response->assertRedirect('/login');
+    }
+
+    /**
+     * Test that an authenticated non-tkd user gets a 403 on the members page.
+     */
+    public function test_authenticated_non_tkd_user_access_to_members_page(): void
+    {
+        // Create a user with tkd = false
+        $user = User::factory()->create(['tkd' => false]);
+
+        // Authenticate as this user
+        $this->actingAs($user);
+
+        // Make a GET request to /programs/taekwondo/members
+        $response = $this->get('/programs/taekwondo/members');
+
+        // Assert that the response is a 403 Forbidden error
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
This commit introduces a new dedicated members area for Taekwondo program participants.

Key changes:
- Added a `tkd` boolean attribute to the `User` model and a corresponding database migration.
- Created a new route `/programs/taekwondo/members` which renders a new Inertia page component `Programs/Taekwondo/Members.vue`. This route requires authentication.
- Updated `ProgramController` to redirect authenticated users with `tkd=true` from `/programs/taekwondo` to the new `/programs/taekwondo/members` route.
- Added basic content to the new `Members.vue` page.
- Implemented tests to cover:
    - Redirection of TKD members from the public Taekwondo page to the members area.
    - Access for non-TKD members to the public Taekwondo page.
    - Redirection of unauthenticated users from the members area to login.
    - Forbidden (403) access for authenticated non-TKD users trying to access the members area directly.